### PR TITLE
fix: truncate Discord embed fields to stay within API limits

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,12 @@ interface NotionWebhookBody {
 	data: PageObjectResponse;
 }
 
+function truncate(text: string, maxLength: number): string {
+	const chars = [...text]; // Avoid splitting surrogate pairs
+	if (chars.length <= maxLength) return text;
+	return `${chars.slice(0, maxLength - 1).join("")}…`;
+}
+
 async function sendDiscordMessage(
 	token: string,
 	channelId: string,
@@ -52,12 +58,12 @@ app.post("/:discordChannelId", async (c) => {
 	await sendDiscordMessage(c.env.DISCORD_BOT_TOKEN, discordChannelId, {
 		embeds: [
 			{
-				title,
+				title: title === undefined ? undefined : truncate(title, 256),
 				color: 0x2f3437,
 				url: body.data.url,
 				fields: Object.entries(body.data.properties).map(([key, property]) => ({
-					name: key,
-					value: formatProperty(property),
+					name: truncate(key, 256),
+					value: truncate(formatProperty(property), 1024),
 					inline: true,
 				})),
 			},

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -65,4 +65,67 @@ describe("Notion to Discord Bot worker", () => {
 			}),
 		);
 	});
+
+	it("truncates embed fields that exceed Discord length limits", async () => {
+		const channelId = "1234567890123456789";
+		const longText = "a".repeat(2000);
+		const longFieldName = "n".repeat(300);
+		const longTitle = "t".repeat(300);
+
+		const response = await app.request(
+			`/${channelId}?title=${encodeURIComponent(longTitle)}`,
+			{
+				method: "POST",
+				body: JSON.stringify({
+					data: {
+						url: "https://example.com",
+						properties: {
+							[longFieldName]: {
+								type: "rich_text",
+								rich_text: [
+									{
+										type: "text",
+										text: { content: longText, link: null },
+										annotations: {
+											bold: false,
+											italic: false,
+											strikethrough: false,
+											underline: false,
+											code: false,
+											color: "default",
+										},
+										plain_text: longText,
+										href: null,
+									},
+								],
+							},
+						},
+					},
+				}),
+			},
+			{
+				DISCORD_BOT_TOKEN: "dummy-token",
+			},
+		);
+
+		expect(response.status).toBe(204);
+
+		const [, requestInit] = mockFetch.mock.calls[0] as [
+			string,
+			{ body: string },
+		];
+		const message = JSON.parse(requestInit.body) as {
+			embeds: Array<{
+				title: string;
+				fields: Array<{ name: string; value: string }>;
+			}>;
+		};
+
+		expect(message.embeds[0].title).toHaveLength(256);
+		expect(message.embeds[0].title.endsWith("…")).toBe(true);
+		expect(message.embeds[0].fields[0].name).toHaveLength(256);
+		expect(message.embeds[0].fields[0].name.endsWith("…")).toBe(true);
+		expect(message.embeds[0].fields[0].value).toHaveLength(1024);
+		expect(message.embeds[0].fields[0].value.endsWith("…")).toBe(true);
+	});
 });


### PR DESCRIPTION
## Summary
- Add a `truncate` helper that safely shortens strings without splitting surrogate pairs
- Truncate embed field names and titles to 256 characters, and field values to 1024 characters before sending to Discord
- Add a test to verify truncation is applied when Notion properties exceed Discord's length limits

## Test plan
- [x] `bun run test`
- [ ] Verify a Notion page with long property values posts successfully to Discord


Made with [Cursor](https://cursor.com)